### PR TITLE
Updated readme - wrong link to downloader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ZeroCore
 The main repository that Zero Engine is built from.
 
-Visit https://download.zeroengine.io to get the launcher.
+Visit http://downloadlauncher.zeroengine.io/ to get the launcher.
 Visit https://docs.zeroengine.io to view the documentation.


### PR DESCRIPTION
Was having trouble downloading the launcher, found another link that works. Want to update the readme to reflect the correct link.